### PR TITLE
Add OPTIONS request handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ fastify.get("/api", fastifyApolloHandler(apollo))
 
 fastify.route({
   url: "/graphql",
-  method: ["GET", "POST"],
+  method: ["GET", "POST", "OPTIONS"],
   handler: fastifyApolloHandler(apollo),
 })
 ```
@@ -137,7 +137,7 @@ export type ApolloFastifyContextFunction<Context> = (request: FastifyRequest, re
   - default: `"/graphql"`
 - `method`
   - type: `HTTPMethod | HTTPMethod[]`
-  - default: `["GET", "POST"]`
+  - default: `["GET", "POST", "OPTIONS"]`
 - `context`
   - type: [ApolloFastifyContextFunction](#ApolloFastifyContextFunction)
   - default: `async () => ({})`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -44,7 +44,7 @@ export function fastifyApollo<
 		async (fastify, options) => {
 			const {
 				path = "/graphql",
-				method = ["GET", "POST"],
+				method = ["GET", "POST", "OPTIONS"],
 				...handlerOptions
 			} = options
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,10 @@ export interface ApolloFastifyHandlerOptions<Context extends BaseContext = BaseC
 	context?: ApolloFastifyContextFunction<Context, RawServer>,
 }
 
-export interface ApolloFastifyPluginOptions<Context extends BaseContext = BaseContext, RawServer extends RawServerBase = RawServerDefault> extends
-	ApolloFastifyHandlerOptions<Context, RawServer> {
-	path?: string,
-	method?: ValueOrArray<Extract<HTTPMethods, "GET" | "POST">>,
+export interface ApolloFastifyPluginOptions<
+  Context extends BaseContext = BaseContext,
+  RawServer extends RawServerBase = RawServerDefault
+> extends ApolloFastifyHandlerOptions<Context, RawServer> {
+  path?: string;
+  method?: ValueOrArray<Extract<HTTPMethods, "GET" | "POST" | "OPTIONS">>;
 }


### PR DESCRIPTION
Apollo Server's landing pages (sandbox, explorer) will send preflight OPTIONS requests to Apollo Server for CORS purposes.

https://github.com/apollographql/apollo-server/blob/version-4/docs/source/security/cors.mdx#preventing-cross-site-request-forgery-csrf