### PR TITLE
Configure jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "@jest/types";
+
+const config: Config.InitialOptions = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["src", "tests"],
+  testMatch: ["**/*.test.ts"],
+  globals: {
+    "ts-jest": {
+      tsconfig: "<rootDir>/tsconfig.json",
+    },
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
 		"prepublishOnly": "clear && npm run delete-build && npm run build",
 		"postpublish": "npm run push",
 		"sync": "git checkout . && git remote update && git pull",
-		"push": "git add -A && git commit -m \"Update\" && git push"
+		"push": "git add -A && git commit -m \"Update\" && git push",
+		"test": "jest --verbose",
+    "test:ci": "jest --coverage --ci --maxWorkers=2 --reporters=default --reporters=jest-junit"
 	},
 	"peerDependencies": {
 		"@apollo/server": ">=4.0.0-alpha",
@@ -76,6 +78,7 @@
 		"jest-junit": "14.0.0",
 		"pg": "8.7.3",
 		"ts-jest": "28.0.7",
+		"ts-node": "10.9.1",
 		"typescript": "4.7.4"
 	},
 	"dependencies": {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -33,8 +33,9 @@ export function fastifyApolloHandler<
 	apollo: ApolloServer<Context>,
 	options?: WithRequired<ApolloFastifyHandlerOptions<Context, RawServer>, "context">,
 ): RouteHandlerMethod<RawServer> {
+	apollo.assertStarted("fastifyApolloHandler()")
+	
 	return async (request, reply) => {
-		apollo.assertStarted("fastifyApolloHandler()")
 
 		const defaultContext: ApolloFastifyContextFunction<Context, RawServer> =
 			async () => ({} as Context)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -40,6 +40,8 @@ export function fastifyApollo<
 >(
 	apollo: ApolloServer<Context>,
 ): FastifyPluginAsync<WithRequired<ApolloFastifyPluginOptions<Context, RawServer>, "context">, RawServer, TypeProvider> {
+	apollo.assertStarted("fastifyApolloHandler()")
+
 	return fp(
 		async (fastify, options) => {
 			const {

--- a/tests/fastify-specific.test.ts
+++ b/tests/fastify-specific.test.ts
@@ -4,6 +4,7 @@ import { fastifyApollo } from "../src/plugin"
 
 it("not calling start causes a clear error", async () => {
 	const apollo = new ApolloServer({ typeDefs: "type Query {f: ID}" })
-	expect(() => fastifyApollo(apollo))
-		.toThrow("You must `await apollo.start()`")
+	expect(() => fastifyApollo(apollo)).toThrowError(
+		"You must `await server.start()` before calling `fastifyApolloHandler()`"
+	)
 })

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,11 +1,13 @@
 import Fastify from "fastify"
 import { ApolloServer, ApolloServerOptions, BaseContext } from "@apollo/server"
 import { defineIntegrationTestSuite } from "@apollo/server-integration-testsuite"
-import { urlForHttpServer } from "@apollo/server/dist/esm/utils/urlForHttpServer"
 import { ApolloServerPluginDrainHttpServer } from "@apollo/server/plugin/drainHttpServer"
 
 import { fastifyApollo } from "../src/plugin"
 import { ApolloFastifyPluginOptions } from "../src/types"
+import { Server } from "http"
+import { AddressInfo } from "net"
+import { format } from "url"
 
 interface MyContext {
 	foo: "bar",
@@ -24,7 +26,7 @@ defineIntegrationTestSuite(async (
 		...serverOptions,
 		plugins: [
 			...(serverOptions.plugins ?? []),
-			ApolloServerPluginDrainHttpServer<MyContext>({
+			ApolloServerPluginDrainHttpServer({
 				httpServer: fastify.server,
 			}),
 		],
@@ -47,3 +49,21 @@ defineIntegrationTestSuite(async (
 		url: urlForHttpServer(fastify.server),
 	}
 })
+
+function urlForHttpServer(httpServer: Server): string {
+  const { address, port } = httpServer.address() as AddressInfo;
+
+  // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
+  // corresponding loopback ip. Note that the url field we're setting is
+  // primarily for consumption by our test suite. If this heuristic is wrong for
+  // your use case, explicitly specify a frontend host (in the `host` option
+  // when listening).
+  const hostname = address === '' || address === '::' ? 'localhost' : address;
+
+  return format({
+    protocol: 'http',
+    hostname,
+    port,
+    pathname: '/',
+  });
+}


### PR DESCRIPTION
Integration tests aren't passing yet, but this configures Jest so that tests can be run with the `npm test` command (or just `npm t` for short).