### PR TITLE
Remove circleci checks for Node < 20 to unblock fastify 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,5 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16"
-                - "18"
                 - "20"
       - Incremental Delivery


### PR DESCRIPTION
The Fastify v5 PR (#302) is blocked by the Node < 20 checks not being run. 
These checks have been removed on that branch because Fastify v5 requires Node 20+.
The hope is that once these checks are removed from main then they will no longer be required on by pull requests.